### PR TITLE
Nix: add nickel language server to devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           with pkgs; [
             sdcc
             nickel
+            nls
             meson
             python311
             ninja


### PR DESCRIPTION
Nickel has a [language server](https://microsoft.github.io/language-server-protocol/).

There's little cost to adding it to the Nix devshell; and there's some benefit to using LSP when editing Nickel files.