### PR TITLE
fak.py: wait for bootloader in flash command

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -90,3 +90,7 @@ foreach side : sides
         depends : ihx,
     )
 endforeach
+
+wchisp_info = run_target('wchisp_info',
+    command : [wchisp, 'info'],
+)


### PR DESCRIPTION
This improves the UX when running `python fak.py flash`, allowing the CH552 to enter bootloader mode after the `flash` command is invoked.

Previously, `python fak.py flash` will fail if the CH552 keyboard isn't in bootloader mode, which essentially means the user has to remember to enter the bootloader before running the `flash` command.

The `wchisp info` will succeed if the CH552 bootloader is available, and will fail if no bootloader is not available. (`wchisp flash` is also going to fail if no bootloader is available).

So, `wchisp info` can be used to check for the presence of a bootloader before running `wchisp flash`. Looping this check every few seconds gives the user the chance to put the keyboard into bootloader mode after running `python fak.py flash`.