### PR TITLE
Impl caps word

### DIFF
--- a/ncl/fak/gen_ir.ncl
+++ b/ncl/fak/gen_ir.ncl
@@ -96,6 +96,7 @@ let encode_tappable = fun { type, data } => match {
       'user => 2,
       'mouse => 3,
       'macro => 4,
+      'caps_word => 5,
     } data.type,
   'transparent => 65535
 } type in
@@ -240,6 +241,8 @@ let _central_defines = {
   MACRO_STEP_ARG_COUNT = std.array.length _macro_step_args,
 
   CONDITIONAL_LAYER_COUNT = std.record.length km.conditional_layers,
+
+  CAPS_WORD_ENABLE = is_custom_keys_of_type_used 'caps_word,
 
   COMBO_COUNT = combo_count,
   COMBO_REQUIRE_PRIOR_IDLE_MS_ENABLE = combos

--- a/ncl/fak/gen_ir.ncl
+++ b/ncl/fak/gen_ir.ncl
@@ -96,7 +96,6 @@ let encode_tappable = fun { type, data } => match {
       'user => 2,
       'mouse => 3,
       'macro => 4,
-      'caps_word => 5,
     } data.type,
   'transparent => 65535
 } type in
@@ -177,6 +176,15 @@ let is_custom_keys_of_type_used = fun type =>
       && kc.data.tap.data.type == type)
 in
 
+let is_custom_keys_of_type_of_keycodes_used = fun type keycodes =>
+  deep_keycodes
+  |> std.array.any (fun kc =>
+      kc.type == 'hold_tap
+      && kc.data.tap.type == 'custom
+      && kc.data.tap.data.type == type
+      && std.array.elem kc.data.tap.data.data.code keycodes)
+in
+
 let encode_macro_step_arg = fun step =>
   match {
     'wait => step.arg.duration_ms,
@@ -242,7 +250,7 @@ let _central_defines = {
 
   CONDITIONAL_LAYER_COUNT = std.record.length km.conditional_layers,
 
-  CAPS_WORD_ENABLE = is_custom_keys_of_type_used 'caps_word,
+  CAPS_WORD_ENABLE = is_custom_keys_of_type_of_keycodes_used 'fak [2, 3, 4],
 
   COMBO_COUNT = combo_count,
   COMBO_REQUIRE_PRIOR_IDLE_MS_ENABLE = combos

--- a/ncl/fak/gen_meson_options.ncl
+++ b/ncl/fak/gen_meson_options.ncl
@@ -11,7 +11,8 @@ fun ir =>
       "src/combo.c" = ir.defines.COMBO_COUNT > 0,
       "src/mouse.c" = ir.defines.MOUSE_KEYS_ENABLE,
       "src/macro.c" = ir.defines.MACRO_KEYS_ENABLE,
-    } 
+      "src/caps_word.c" = ir.defines.CAPS_WORD_ENABLE,
+    }
     |> std.record.filter (fun _k pred => pred)
     |> std.record.to_array
     |> std.array.map (fun e => e.field)

--- a/ncl/fak/keycode.ncl
+++ b/ncl/fak/keycode.ncl
@@ -89,6 +89,9 @@ let mod_ = fun K => let K = fun mod => K { mods."%{mod}" = true } in {
         WH_U = K 12,
         WH_D = K 13,
       },
+      caps_word = let K = fun code => K 'caps_word code in {
+        TOGG = K 0,
+      },
     },
     trans = K 'transparent {},
   },

--- a/ncl/fak/keycode.ncl
+++ b/ncl/fak/keycode.ncl
@@ -63,7 +63,10 @@ let mod_ = fun K => let K = fun mod => K { mods."%{mod}" = true } in {
     custom = let K = fun t c => K 'custom { type = t, data.code = c } in {
       fak = let K = fun code => K 'fak code in {
         RESET = K 0,
-        BOOT = K 1,
+        BOOT  = K 1,
+        CWON  = K 2,
+        CWOFF = K 3,
+        CWTG  = K 4,
       },
       media = let K = fun code => K 'consumer code in {
         PLAY = K 205,
@@ -88,9 +91,6 @@ let mod_ = fun K => let K = fun mod => K { mods."%{mod}" = true } in {
         UP =   K 11,
         WH_U = K 12,
         WH_D = K 13,
-      },
-      caps_word = let K = fun code => K 'caps_word code in {
-        TOGG = K 0,
       },
     },
     trans = K 'transparent {},

--- a/ncl/fak/keymap.ncl
+++ b/ncl/fak/keymap.ncl
@@ -98,7 +98,7 @@ let rec Keycode =
         layer | NonConditionalLayerIndex
       },
       'custom => {
-        type | [| 'fak, 'consumer, 'user, 'mouse, 'macro |],
+        type | [| 'fak, 'consumer, 'user, 'mouse, 'macro, 'caps_word |],
         data | (match {
           'macro => 
             let MacroStep = {

--- a/ncl/fak/keymap.ncl
+++ b/ncl/fak/keymap.ncl
@@ -98,7 +98,7 @@ let rec Keycode =
         layer | NonConditionalLayerIndex
       },
       'custom => {
-        type | [| 'fak, 'consumer, 'user, 'mouse, 'macro, 'caps_word |],
+        type | [| 'fak, 'consumer, 'user, 'mouse, 'macro |],
         data | (match {
           'macro => 
             let MacroStep = {

--- a/src/caps_word.c
+++ b/src/caps_word.c
@@ -15,7 +15,7 @@ __bit caps_word_active() {
     return caps_word_state;
 }
 
-__bit caps_word_handle_key(uint8_t code) {
+__bit caps_word_handle_key(uint8_t code, uint8_t shift_pressed) {
   if (caps_word_state == 0) {
     return 0;
   }
@@ -30,7 +30,7 @@ __bit caps_word_handle_key(uint8_t code) {
   if ((code >= 0x04) && code < (0x04 + 26)) {
     // A..Z
     return 1;
-  } else if ((code >= 0x04 + 26) && code < (0x04 + 26 + 10)) { // 1..0
+  } else if (!shift_pressed && (code >= 0x04 + 26) && code < (0x04 + 26 + 10)) { // 1..0
   } else if (code == 0x2A) { // backspace
   } else if (code == 0x2D) { // minus
     return 1;

--- a/src/caps_word.c
+++ b/src/caps_word.c
@@ -2,6 +2,9 @@
 
 #include "ch552.h"
 
+#include "time.h"
+#include "split_central.h"
+
 __bit caps_word_state = 0;
 
 void caps_word_toggle() {
@@ -14,6 +17,12 @@ __bit caps_word_active() {
 
 __bit caps_word_handle_key(uint8_t code) {
   if (caps_word_state == 0) {
+    return 0;
+  }
+
+  // check hasn't timed out
+  if ((get_timer() - get_last_tap_timestamp()) > 5000) {
+    caps_word_state = 0;
     return 0;
   }
 

--- a/src/caps_word.c
+++ b/src/caps_word.c
@@ -1,0 +1,35 @@
+#include "caps_word.h"
+
+#include "ch552.h"
+
+__bit caps_word_state = 0;
+
+void caps_word_toggle() {
+    caps_word_state = !caps_word_state;
+}
+
+__bit caps_word_active() {
+    return caps_word_state;
+}
+
+__bit caps_word_handle_key(uint8_t code) {
+  if (caps_word_state == 0) {
+    return 0;
+  }
+
+  // this assumes US layout on the host OS.
+  if ((code >= 0x04) && code < (0x04 + 26)) {
+    // A..Z
+    return 1;
+  } else if ((code >= 0x04 + 26) && code < (0x04 + 26 + 10)) { // 1..0
+  } else if (code == 0x2A) { // backspace
+  } else if (code == 0x2D) { // minus
+    return 1;
+  } else if (code == 0x4C) { // delete
+  } else {
+    // otherwise: not an accepted key; disable caps word
+    caps_word_state = 0;
+  }
+
+  return 0;
+}

--- a/src/caps_word.c
+++ b/src/caps_word.c
@@ -7,6 +7,14 @@
 
 __bit caps_word_state = 0;
 
+void caps_word_on() {
+    caps_word_state = 1;
+}
+
+void caps_word_off() {
+    caps_word_state = 0;
+}
+
 void caps_word_toggle() {
     caps_word_state = !caps_word_state;
 }

--- a/src/caps_word.h
+++ b/src/caps_word.h
@@ -1,0 +1,22 @@
+#ifndef CAPS_WORD_H_
+#define CAPS_WORD_H_
+
+#include <stdint.h>
+
+#include "ch552.h"
+
+void caps_word_toggle();
+
+__bit caps_word_active();
+
+// Process the logic for caps word for the given key.
+//
+// If keys other than A-Z, 0-9, -, _, backspace, delete are pressed,
+// exit caps word mode.
+//
+// Does nothing if caps word word is not active.
+//
+// Returns 1 if the needs to press shift key for the key, 0 otherwise.
+__bit caps_word_handle_key(uint8_t code);
+
+#endif // CAPS_WORD_H_

--- a/src/caps_word.h
+++ b/src/caps_word.h
@@ -17,6 +17,6 @@ __bit caps_word_active();
 // Does nothing if caps word word is not active.
 //
 // Returns 1 if the needs to press shift key for the key, 0 otherwise.
-__bit caps_word_handle_key(uint8_t code);
+__bit caps_word_handle_key(uint8_t code, uint8_t shift_pressed);
 
 #endif // CAPS_WORD_H_

--- a/src/caps_word.h
+++ b/src/caps_word.h
@@ -5,6 +5,8 @@
 
 #include "ch552.h"
 
+void caps_word_on();
+void caps_word_off();
 void caps_word_toggle();
 
 __bit caps_word_active();

--- a/src/split_central.c
+++ b/src/split_central.c
@@ -334,7 +334,8 @@ void handle_non_future(uint32_t key_code, uint8_t down) {
 
 #ifdef CAPS_WORD_ENABLE
         if (down && tap_code && caps_word_active()) {
-            if (caps_word_handle_key(tap_code)) {
+            uint8_t shift_pressed = (strong_mods_ref_count[1] > 0) | tap_mods & 0x02;
+            if (caps_word_handle_key(tap_code, shift_pressed)) {
                 weak_mods |= 0x02; // press shift key
             }
         }

--- a/src/split_central.c
+++ b/src/split_central.c
@@ -298,8 +298,25 @@ void handle_non_future(uint32_t key_code, uint8_t down) {
         switch (custom_type) {
 #ifdef FAK_KEYS_ENABLE
         case 0: // FAK-specific
-            if      (custom_code == 0) sw_reset();
-            else if (custom_code == 1) bootloader();
+            switch (custom_code) {
+            case 0:
+                sw_reset();
+                break;
+            case 1:
+                bootloader();
+                break;
+#ifdef CAPS_WORD_ENABLE
+            case 2:
+                caps_word_on();
+                break;
+            case 3:
+                caps_word_off();
+                break;
+            case 4:
+                if (down) caps_word_toggle();
+                break;
+#endif
+            }
             break;
 #endif
 #ifdef CONSUMER_KEYS_ENABLE
@@ -318,13 +335,6 @@ void handle_non_future(uint32_t key_code, uint8_t down) {
 #ifdef MACRO_KEYS_ENABLE
         case 4: // Macro
             return macro_handle_key(custom_code, down);
-#endif
-#ifdef CAPS_WORD_ENABLE
-        case 5: // Caps Word
-            if (down) {
-                caps_word_toggle();
-            }
-            break;
 #endif
         }
         break;


### PR DESCRIPTION
I don't use this functionality all that much, but it seems nice to have.

This is the implementation I'm using at the moment.

- Adding `custom.caps_word.TOGG` to a keymap enables caps word functionality.
- Tapping `TOGG` toggles the caps word state.
- When active, tapping any key except the alphabetical keys, numbers, backspace, delete deactivates caps word state.
- When active, tapping alphabetical keys sends the shifted alphabetical keys; tapping `-` sends `_`.
- Caps word state only remains active if a key was tapped in the previous 5 seconds.

I haven't checked how this interacts with combos, tap-holds, or tap-dances.