### PR TITLE
Add support for Fast forward and Rewind

### DIFF
--- a/ncl/fak/keycode.ncl
+++ b/ncl/fak/keycode.ncl
@@ -77,6 +77,8 @@ let mod_ = fun K => let K = fun mod => K { mods."%{mod}" = true } in {
         VOLD = K 234,
         NEXT = K 181,
         PREV = K 182,
+        FASTFWD = K 179,
+        REWIND = K 180,
       },
       mouse = let K = fun code => K 'mouse code in {
         BTN1 = K 0,


### PR DESCRIPTION
Love the current media controls, but because the USB spec supports fast forward and rewind, it seems like a no-brainer to add.

This code was tested on a CH552T with Windows, Macos and Linux. All working.

https://www.usb.org/sites/default/files/hut1_5.pdf
